### PR TITLE
Add missing dependency on Unix

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -7,4 +7,4 @@
 (library
  (name cron)
  (public_name crontab)
- (libraries str))
+ (libraries str unix))


### PR DESCRIPTION
Silences the alert proposed in ocaml/ocaml#11198, but this PR can be merged regardless.